### PR TITLE
Moving SerialBluethooth to a better bool casting

### DIFF
--- a/src/SerialBluetooth/SerialBluetooth.cpp
+++ b/src/SerialBluetooth/SerialBluetooth.cpp
@@ -10,13 +10,13 @@ Class to communicate with Sunfounder Bluetooth module
 void SerialBluetooth::init(HardwareSerial& serialCon){
   stream_ptr = &serialCon;
   serialCon.begin(BAUD_RATE_BLUETOOTH);
-  while(!serialCon); // Attente d'ouverture du port serie
+  while(!serialCon.available()); // Attente d'ouverture du port serie
 }
 
 void SerialBluetooth::init(SoftwareSerial& serialCon){
   stream_ptr = &serialCon;
   serialCon.begin(BAUD_RATE_BLUETOOTH);
-  while(!serialCon); // Attente d'ouverture du port serie
+  while(!serialCon.available()); // Attente d'ouverture du port serie
 }
 
 bool SerialBluetooth::read(String& msg){


### PR DESCRIPTION
**Summay**
This is fixing a problem in the new implementation of `HardwareSerial` and `SoftwareSerial` for Arduino (those library are build in)

Signed-off-by: Justin Brûlotte <justin.brlotte797@gmail.com>